### PR TITLE
add `products` to `Package.swift` so SPM will work with Xcode 12

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,12 @@ import PackageDescription
 
 let package = Package(
     name: "Ecoji",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "Ecoji",
+            targets: ["Ecoji"]),
+    ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),


### PR DESCRIPTION
Resolves an issue where Xcode 12.4 refuses to add Ecoji as a package dependency:
`package 'Ecoji' contains no products`